### PR TITLE
refactor: restore fisher V3 support; fix #8

### DIFF
--- a/functions/__fish_cd.fish
+++ b/functions/__fish_cd.fish
@@ -1,0 +1,7 @@
+function __fish_cd
+  if functions -q __wrapped_cd
+    __wrapped_cd $argv
+  else
+    builtin cd $argv
+  end
+end

--- a/functions/__plugin_cd.fish
+++ b/functions/__plugin_cd.fish
@@ -16,14 +16,6 @@
 #   cd ... <=> cd ../..
 #   cd .../foo/.../bar <=> cd ../../foo/../../bar
 
-function __fish_cd
-  if functions -q __wrapped_cd
-    __wrapped_cd $argv
-  else
-    builtin cd $argv
-  end
-end
-
 function __plugin_cd -d "plugin-cd" -a fancy_path
   # private:
   function __empty_cd -S
@@ -31,7 +23,7 @@ function __plugin_cd -d "plugin-cd" -a fancy_path
     set -l output_status $status
 
     __update_pwd
-    
+
     return $output_status
   end
 
@@ -40,14 +32,14 @@ function __plugin_cd -d "plugin-cd" -a fancy_path
     set -l output_status $status
 
     __update_pwd
-    
+
     return $output_status
   end
 
   function __fancy_cd -S
 		set extract_from_right (echo $fancy_path | sed -n '/^+\([0-9]\)$/  s//\1/g p')
 		set extract_from_left (echo $fancy_path | sed -n '/^-\([0-9]\)$/  s//\1/g p')
-    
+
 	  if test -n "$extract_from_right" -o -n "$extract_from_left"
 		  # Generate current stack
 		  set -l stack (command pwd) $dirstack
@@ -74,19 +66,19 @@ function __plugin_cd -d "plugin-cd" -a fancy_path
 			  set -g dirstack $stack[2..(count $stack)]
         __fish_cd $stack[1]
         set -l output_status $status
-        
+
         __update_pwd
 
         return $output_status
 		  end
-    else 
+    else
       set -l normal_path (echo $fancy_path | sed -e 's@^\.$@:@;s@^\.\([^\.]\)@:\1@g;s@\([^\.]\)\.$@\1:@g' -e 's@\([^\.]\)\.\([^\.]\)@\1:\2@g' -e 's@\([^\.]\)\.\([^\.]\)@\1:\2@g' -e 's@\.\{2\}\(\.*\)@::\1@g' -e 's@\.@\/\.\.@g' -e 's@:@\.@g')
 
       __fish_cd $normal_path
       set -l output_status $status
 
       __update_pwd
-      
+
       return $output_status
     end
   end
@@ -104,7 +96,7 @@ function __plugin_cd -d "plugin-cd" -a fancy_path
         set -e dirstack[(contains -i (command pwd) $dirstack)]
       end
   end
-  
+
   function __update_pwd -S
     if test $old_pwd != (command pwd)
       set -xg OLDPWD $old_pwd

--- a/init.fish
+++ b/init.fish
@@ -5,8 +5,4 @@ if not functions -q __plugin_cd_wrapped_cd
   functions -e cd
 end
 
-if not functions -q __plugin_cd
-  source $SOURCE_DIR/functions/plugin-cd.fish
-end
-
 functions -c __plugin_cd cd

--- a/init.fish
+++ b/init.fish
@@ -1,10 +1,4 @@
-set SOURCE_FILE (status -f)
-# For fishman symlink
-while test -L $SOURCE_FILE
-  set SOURCE_FILE (readlink $SOURCE_FILE)
-end
-
-set SOURCE_DIR (dirname $SOURCE_FILE)
+set SOURCE_DIR (dirname (status -f))
 
 if not functions -q __plugin_cd_wrapped_cd
   functions -c cd __plugin_cd_wrapped_cd

--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,3 @@
-#!/usr/local/bin/fish
-
 set SOURCE_FILE (status -f)
 # For fishman symlink
 while test -L $SOURCE_FILE

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -4,3 +4,5 @@ if functions -q __wrapped_cd
   functions -c __wrapped_cd cd
   functions -e __wrapped_cd
 end
+
+functions -e __fish_cd __plugin_cd

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -1,5 +1,3 @@
-#!/usr/local/bin/fish
-
 functions -e cd
 
 if functions -q __wrapped_cd


### PR DESCRIPTION
Hi @SanCoder-Q, @BarbzYHOOL.

This PR fixes #8. None of these changes should block this package to be installed with Oh My Fish, but  do check to make sure I didn't botch anything. If I did, it wasn't intentional. 

See the commits for technical details.

The gist of these changes is removing extraneous code from `init.fish` and using files for functions.

Please read the fish documentation to understand [what autoloading](https://fishshell.com/docs/current/tutorial.html#tut_autoload) is and [how it works](https://fishshell.com/docs/current/index.html#syntax-function-autoloading). 